### PR TITLE
feat: 支持多日去重，防止跨日重复内容影响工作流

### DIFF
--- a/daily_arxiv/daily_arxiv/check_stats.py
+++ b/daily_arxiv/daily_arxiv/check_stats.py
@@ -83,7 +83,7 @@ def perform_deduplication():
 
     try:
         today_papers, today_ids = load_papers_data(today_file)
-        print(f"今日论文总数: {len(today_papers)}", file=sys.stderr)
+        print(f"今日论文总数: {len(today_papers)} / Today's total papers: {len(today_papers)}", file=sys.stderr)
 
         if not today_papers:
             return "no_data"
@@ -96,36 +96,36 @@ def perform_deduplication():
             _, past_ids = load_papers_data(history_file)
             history_ids.update(past_ids)
 
-        print(f"历史{history_days}日去重库大小: {len(history_ids)}", file=sys.stderr)
+        print(f"历史{history_days}日去重库大小: {len(history_ids)} / History {history_days} days deduplication library size: {len(history_ids)}", file=sys.stderr)
 
         duplicate_ids = today_ids & history_ids
 
         if duplicate_ids:
-            print(f"发现 {len(duplicate_ids)} 篇历史重复论文", file=sys.stderr)
+            print(f"发现 {len(duplicate_ids)} 篇历史重复论文 / Found {len(duplicate_ids)} historical duplicate papers", file=sys.stderr)
             new_papers = [paper for paper in today_papers if paper.get('id', '') not in duplicate_ids]
 
-            print(f"去重后剩余论文数: {len(new_papers)}", file=sys.stderr)
+            print(f"去重后剩余论文数: {len(new_papers)} / Remaining papers after deduplication: {len(new_papers)}", file=sys.stderr)
 
             if new_papers:
                 if save_papers_data(new_papers, today_file):
-                    print(f"已更新今日文件，移除 {len(duplicate_ids)} 篇重复论文", file=sys.stderr)
+                    print(f"已更新今日文件，移除 {len(duplicate_ids)} 篇重复论文 / Today's file updated, removed {len(duplicate_ids)} duplicate papers", file=sys.stderr)
                     return "has_new_content"
                 else:
-                    print("保存去重后的数据失败", file=sys.stderr)
+                    print("保存去重后的数据失败 / Failed to save deduplicated data", file=sys.stderr)
                     return "error"
             else:
                 try:
                     os.remove(today_file)
-                    print("所有论文均为重复内容，已删除今日文件", file=sys.stderr)
+                    print("所有论文均为重复内容，已删除今日文件 / All papers are duplicate content, today's file deleted", file=sys.stderr)
                 except Exception as e:
-                    print(f"删除文件失败: {e}", file=sys.stderr)
+                    print(f"删除文件失败: {e} / Failed to delete file: {e}", file=sys.stderr)
                 return "no_new_content"
         else:
-            print("所有内容均为新内容", file=sys.stderr)
+            print("所有内容均为新内容 / All content is new", file=sys.stderr)
             return "has_new_content"
 
     except Exception as e:
-        print(f"去重处理失败: {e}", file=sys.stderr)
+        print(f"去重处理失败: {e} / Deduplication processing failed: {e}", file=sys.stderr)
         return "error"
 
 def main():


### PR DESCRIPTION
## 更新内容 / What’s Changed

本次 PR 对 `check_stats.py` 脚本进行了如下功能增强：

- 将原本仅对比“昨日”的去重逻辑，扩展为对比“过去 N 日”（当前默认 7 天）论文 ID。
- 支持从历史多日中剔除重复内容，防止出现 **“今日内容与前日不重复，但与前前日完全一致”** 的问题。
- 去重逻辑保持不变：若全部重复，则删除当天数据文件，返回“无新内容”状态。

## 背景说明 / Why This Change

部署本项目后，我将关注领域从默认的 `cs.AI` 改为 `cs.SE`（计算机科学-软件工程）。由于该子领域每天新论文数量较少，GitHub Actions 运行过程中出现以下问题：

- 某一天（如 7月13日）与 7月11日的论文完全相同，7月12日并未生成jsonl文件；
- 原先的去重机制只检查前一天，误判为“有新内容”；
- 导致连续生成内容重复的文件，并继续触发下游处理。

这种情况下容易浪费计算资源或误导后续分析，因此增加 **多日历史对比** 是必要的。

## 其他说明 / Additional Notes

- 当前默认对比过去 7 天，如需修改，可将 `history_days` 参数调大。
- 后续可进一步支持 CLI 参数或配置文件控制对比天数。
- **也可以增加一个 `paper.jsonl` 文件用于存放所有历史论文**，每次爬取后实时追加更新，这样不需要指定“过去几天”，可直接在全集中判断重复，更高效、准确。

## ✅ 测试可用 / Tested Successfully

本地修改完成后，已通过 GitHub Actions 成功运行并验证去重效果。

<img width="826" height="321" alt="image" src="https://github.com/user-attachments/assets/625297f8-d028-4056-9979-e55672a4a5e1" />

如图所示，脚本能够准确判断与历史重复的内容并返回正确的状态码，工作流行为符合预期。