### PR TITLE
feat: add MiniMax as alternative LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,37 @@ Otherwise, you can directly use this repo in https://dw-dengwei.github.io/daily-
 9. You can manually click **Run workflow** to test if it works well (it may take about one hour). By default, this action will automatically run every day. You can modify it in `.github/workflows/run.yml`
 10. Set up GitHub pages: Go to your own repo -> Settings -> Pages. In `Build and deployment`, set `Source="Deploy from a branch"`, `Branch="main", "/(root)"`. Wait for a few minutes, go to https://\<username\>.github.io/daily-arXiv-ai-enhanced/. Please see this [issue](https://github.com/dw-dengwei/daily-arXiv-ai-enhanced/issues/14) for more precise instructions.
 
+## Supported LLM Providers
+
+The project supports multiple OpenAI-compatible LLM providers. You can switch providers by setting the corresponding API key environment variable (auto-detected), or explicitly via `LLM_PROVIDER`.
+
+| Provider | API Key Env | Default Model | Notes |
+|----------|-------------|---------------|-------|
+| [DeepSeek](https://platform.deepseek.com/) | `DEEPSEEK_API_KEY` | `deepseek-chat` | Default provider |
+| [MiniMax](https://www.minimaxi.com/) | `MINIMAX_API_KEY` | `MiniMax-M2.7` | 1M context, function calling |
+| [OpenAI](https://platform.openai.com/) | `OPENAI_API_KEY` | `gpt-4o` | Requires `OPENAI_BASE_URL` to be unset |
+
+### Using MiniMax
+
+[MiniMax](https://www.minimaxi.com/) provides high-quality, cost-effective models with OpenAI-compatible API. To use MiniMax:
+
+**Option A – Auto-detection (recommended):**
+```bash
+# Set MiniMax API key; provider and base URL are auto-configured
+export MINIMAX_API_KEY="your-minimax-api-key"
+# Optionally override the model (default: MiniMax-M2.7)
+export MODEL_NAME="MiniMax-M2.5-highspeed"   # 204K context, faster
+```
+
+**Option B – Manual configuration (GitHub Actions secrets):**
+```
+OPENAI_API_KEY   = your-minimax-api-key
+OPENAI_BASE_URL  = https://api.minimax.io/v1
+MODEL_NAME       = MiniMax-M2.7
+```
+
+Available MiniMax models: `MiniMax-M2.7` (latest, 1M context), `MiniMax-M2.5`, `MiniMax-M2.5-highspeed` (204K context, faster).
+
 # Plans
 See https://github.com/users/dw-dengwei/projects/3
 

--- a/ai/enhance.py
+++ b/ai/enhance.py
@@ -21,6 +21,7 @@ from langchain.prompts import (
     HumanMessagePromptTemplate,
 )
 from structure import Structure
+from providers import detect_provider, get_provider_config, clamp_temperature
 
 if os.path.exists('.env'):
     dotenv.load_dotenv()
@@ -165,10 +166,24 @@ def process_single_item(chain, item: Dict, language: str) -> Dict:
             return None
     return item
 
-def process_all_items(data: List[Dict], model_name: str, language: str, max_workers: int) -> List[Dict]:
+def process_all_items(data: List[Dict], model_name: str, language: str, max_workers: int,
+                      provider: str = None) -> List[Dict]:
     """并行处理所有数据项"""
-    llm = ChatOpenAI(model=model_name).with_structured_output(Structure, method="function_calling")
-    print('Connect to:', model_name, file=sys.stderr)
+    config = get_provider_config(provider)
+    effective_model = model_name or config["model_name"]
+
+    llm_kwargs = {"model": effective_model}
+    if config.get("api_key"):
+        llm_kwargs["api_key"] = config["api_key"]
+    if config.get("base_url"):
+        llm_kwargs["base_url"] = config["base_url"]
+
+    # Clamp temperature for providers with restricted ranges (e.g. MiniMax)
+    temperature = clamp_temperature(0.7, provider)
+    llm_kwargs["temperature"] = temperature
+
+    llm = ChatOpenAI(**llm_kwargs).with_structured_output(Structure, method="function_calling")
+    print(f'Connect to: {effective_model} (provider: {provider or "default"})', file=sys.stderr)
     
     prompt_template = ChatPromptTemplate.from_messages([
         SystemMessagePromptTemplate.from_template(system),
@@ -212,7 +227,9 @@ def process_all_items(data: List[Dict], model_name: str, language: str, max_work
 
 def main():
     args = parse_args()
-    model_name = os.environ.get("MODEL_NAME", 'deepseek-chat')
+    provider = detect_provider()
+    config = get_provider_config(provider)
+    model_name = os.environ.get("MODEL_NAME") or config["model_name"]
     language = os.environ.get("LANGUAGE", 'Chinese')
 
     # 检查并删除目标文件
@@ -237,13 +254,14 @@ def main():
 
     data = unique_data
     print('Open:', args.data, file=sys.stderr)
-    
+
     # 并行处理所有数据
     processed_data = process_all_items(
         data,
         model_name,
         language,
-        args.max_workers
+        args.max_workers,
+        provider=provider,
     )
     
     # 保存结果

--- a/ai/providers.py
+++ b/ai/providers.py
@@ -1,0 +1,101 @@
+"""
+LLM provider presets for daily-arXiv-ai-enhanced.
+
+Provides auto-detection and configuration for multiple OpenAI-compatible
+LLM providers, including DeepSeek, MiniMax, and OpenAI.
+"""
+
+import os
+from typing import Dict, Optional
+
+# Provider preset configurations
+PROVIDER_PRESETS: Dict[str, Dict] = {
+    "deepseek": {
+        "base_url": "https://api.deepseek.com/v1",
+        "api_key_env": "DEEPSEEK_API_KEY",
+        "default_model": "deepseek-chat",
+        "temperature_range": (0.0, 2.0),
+    },
+    "minimax": {
+        "base_url": "https://api.minimax.io/v1",
+        "api_key_env": "MINIMAX_API_KEY",
+        "default_model": "MiniMax-M2.7",
+        "temperature_range": (0.0, 1.0),
+        "models": [
+            "MiniMax-M2.7",
+            "MiniMax-M2.5",
+            "MiniMax-M2.5-highspeed",
+        ],
+    },
+    "openai": {
+        "base_url": "https://api.openai.com/v1",
+        "api_key_env": "OPENAI_API_KEY",
+        "default_model": "gpt-4o",
+        "temperature_range": (0.0, 2.0),
+    },
+}
+
+
+def detect_provider() -> Optional[str]:
+    """Auto-detect LLM provider from environment variables.
+
+    Checks provider-specific API key env vars in order:
+    MINIMAX_API_KEY, DEEPSEEK_API_KEY, OPENAI_API_KEY.
+
+    Returns the provider name or None if only generic OPENAI_* vars are set
+    (which means the user configured a custom provider manually).
+    """
+    if os.environ.get("LLM_PROVIDER"):
+        provider = os.environ["LLM_PROVIDER"].lower()
+        if provider in PROVIDER_PRESETS:
+            return provider
+
+    if os.environ.get("MINIMAX_API_KEY"):
+        return "minimax"
+    if os.environ.get("DEEPSEEK_API_KEY"):
+        return "deepseek"
+
+    return None
+
+
+def clamp_temperature(temperature: float, provider: Optional[str] = None) -> float:
+    """Clamp temperature to the valid range for the given provider."""
+    if provider and provider in PROVIDER_PRESETS:
+        lo, hi = PROVIDER_PRESETS[provider]["temperature_range"]
+        return max(lo, min(hi, temperature))
+    return temperature
+
+
+def get_provider_config(provider: Optional[str] = None) -> Dict:
+    """Get LLM configuration from provider preset or environment variables.
+
+    If a provider is specified (or auto-detected), applies its preset
+    configuration as defaults. Environment variables OPENAI_API_KEY,
+    OPENAI_BASE_URL, and MODEL_NAME always take precedence when set.
+
+    Returns a dict with keys: base_url, api_key, model_name.
+    """
+    config = {}
+
+    if provider and provider in PROVIDER_PRESETS:
+        preset = PROVIDER_PRESETS[provider]
+
+        # Use provider-specific API key, fall back to OPENAI_API_KEY
+        api_key = os.environ.get(preset["api_key_env"]) or os.environ.get("OPENAI_API_KEY", "")
+        config["api_key"] = api_key
+        config["base_url"] = preset["base_url"]
+        config["model_name"] = preset["default_model"]
+    else:
+        config["api_key"] = os.environ.get("OPENAI_API_KEY", "")
+        config["base_url"] = None
+        config["model_name"] = "deepseek-chat"
+
+    # Environment variables always override preset defaults
+    if os.environ.get("OPENAI_BASE_URL"):
+        config["base_url"] = os.environ["OPENAI_BASE_URL"]
+    if os.environ.get("OPENAI_API_KEY") and not provider:
+        config["api_key"] = os.environ["OPENAI_API_KEY"]
+    if os.environ.get("MODEL_NAME"):
+        config["model_name"] = os.environ["MODEL_NAME"]
+
+    return config

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,106 @@
+"""Integration tests for MiniMax provider with the enhance pipeline.
+
+These tests verify end-to-end configuration and LLM instantiation.
+Tests that require actual API calls are skipped unless MINIMAX_API_KEY is set.
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "ai"))
+
+from providers import detect_provider, get_provider_config
+
+
+class TestMiniMaxEndToEnd(unittest.TestCase):
+    """Integration tests for MiniMax provider configuration flow."""
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "test-key-123"}, clear=True)
+    def test_full_autodetect_flow(self):
+        """Test auto-detection -> config resolution -> LLM kwargs pipeline."""
+        provider = detect_provider()
+        self.assertEqual(provider, "minimax")
+
+        config = get_provider_config(provider)
+        self.assertEqual(config["base_url"], "https://api.minimax.io/v1")
+        self.assertEqual(config["api_key"], "test-key-123")
+        self.assertEqual(config["model_name"], "MiniMax-M2.7")
+
+    @patch.dict(os.environ, {
+        "LLM_PROVIDER": "minimax",
+        "MINIMAX_API_KEY": "mk",
+        "MODEL_NAME": "MiniMax-M2.5-highspeed",
+    }, clear=True)
+    def test_explicit_provider_with_model_override(self):
+        """Test explicit provider + MODEL_NAME override."""
+        provider = detect_provider()
+        self.assertEqual(provider, "minimax")
+
+        config = get_provider_config(provider)
+        self.assertEqual(config["model_name"], "MiniMax-M2.5-highspeed")
+        self.assertEqual(config["api_key"], "mk")
+
+    @patch.dict(os.environ, {
+        "OPENAI_API_KEY": "minimax-key",
+        "OPENAI_BASE_URL": "https://api.minimax.io/v1",
+        "MODEL_NAME": "MiniMax-M2.7",
+    }, clear=True)
+    def test_manual_openai_compat_config(self):
+        """Test manual configuration via OPENAI_* env vars (no auto-detect)."""
+        provider = detect_provider()
+        self.assertIsNone(provider)
+
+        config = get_provider_config(provider)
+        self.assertEqual(config["base_url"], "https://api.minimax.io/v1")
+        self.assertEqual(config["api_key"], "minimax-key")
+        self.assertEqual(config["model_name"], "MiniMax-M2.7")
+
+
+@unittest.skipUnless(
+    os.environ.get("MINIMAX_API_KEY"),
+    "MINIMAX_API_KEY not set — skipping live API tests",
+)
+class TestMiniMaxLiveAPI(unittest.TestCase):
+    """Live API tests — only run when MINIMAX_API_KEY is available."""
+
+    def test_chat_completion(self):
+        """Test a real chat completion call to MiniMax API."""
+        from langchain_openai import ChatOpenAI
+
+        config = get_provider_config("minimax")
+        llm = ChatOpenAI(
+            model=config["model_name"],
+            api_key=config["api_key"],
+            base_url=config["base_url"],
+            temperature=0.1,
+        )
+        response = llm.invoke("Say 'hello' in one word.")
+        self.assertIsNotNone(response.content)
+        self.assertGreater(len(response.content), 0)
+
+    def test_structured_output(self):
+        """Test structured output (function calling) with MiniMax."""
+        from langchain_openai import ChatOpenAI
+
+        from structure import Structure
+
+        config = get_provider_config("minimax")
+        llm = ChatOpenAI(
+            model=config["model_name"],
+            api_key=config["api_key"],
+            base_url=config["base_url"],
+            temperature=0.1,
+        ).with_structured_output(Structure, method="function_calling")
+
+        result = llm.invoke(
+            "This paper proposes a new attention mechanism that reduces "
+            "computational complexity from O(n^2) to O(n log n)."
+        )
+        self.assertIsInstance(result, Structure)
+        self.assertGreater(len(result.tldr), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,145 @@
+"""Unit tests for the LLM provider configuration system."""
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+# Add ai/ directory to path so we can import providers
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "ai"))
+
+from providers import (
+    PROVIDER_PRESETS,
+    clamp_temperature,
+    detect_provider,
+    get_provider_config,
+)
+
+
+class TestProviderPresets(unittest.TestCase):
+    """Tests for PROVIDER_PRESETS structure."""
+
+    def test_all_presets_have_required_keys(self):
+        required_keys = {"base_url", "api_key_env", "default_model", "temperature_range"}
+        for name, preset in PROVIDER_PRESETS.items():
+            for key in required_keys:
+                self.assertIn(key, preset, f"Provider '{name}' missing key '{key}'")
+
+    def test_minimax_preset_values(self):
+        p = PROVIDER_PRESETS["minimax"]
+        self.assertEqual(p["base_url"], "https://api.minimax.io/v1")
+        self.assertEqual(p["api_key_env"], "MINIMAX_API_KEY")
+        self.assertEqual(p["default_model"], "MiniMax-M2.7")
+        self.assertEqual(p["temperature_range"], (0.0, 1.0))
+        self.assertIn("MiniMax-M2.5-highspeed", p["models"])
+
+    def test_deepseek_preset_values(self):
+        p = PROVIDER_PRESETS["deepseek"]
+        self.assertEqual(p["base_url"], "https://api.deepseek.com/v1")
+        self.assertEqual(p["default_model"], "deepseek-chat")
+
+    def test_openai_preset_values(self):
+        p = PROVIDER_PRESETS["openai"]
+        self.assertEqual(p["base_url"], "https://api.openai.com/v1")
+        self.assertEqual(p["default_model"], "gpt-4o")
+
+
+class TestDetectProvider(unittest.TestCase):
+    """Tests for detect_provider() auto-detection."""
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_no_env_returns_none(self):
+        self.assertIsNone(detect_provider())
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "key123"}, clear=True)
+    def test_minimax_api_key_detected(self):
+        self.assertEqual(detect_provider(), "minimax")
+
+    @patch.dict(os.environ, {"DEEPSEEK_API_KEY": "key456"}, clear=True)
+    def test_deepseek_api_key_detected(self):
+        self.assertEqual(detect_provider(), "deepseek")
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "k1", "DEEPSEEK_API_KEY": "k2"}, clear=True)
+    def test_minimax_takes_priority_over_deepseek(self):
+        self.assertEqual(detect_provider(), "minimax")
+
+    @patch.dict(os.environ, {"LLM_PROVIDER": "minimax"}, clear=True)
+    def test_explicit_llm_provider_env(self):
+        self.assertEqual(detect_provider(), "minimax")
+
+    @patch.dict(os.environ, {"LLM_PROVIDER": "openai"}, clear=True)
+    def test_explicit_openai_provider(self):
+        self.assertEqual(detect_provider(), "openai")
+
+    @patch.dict(os.environ, {"LLM_PROVIDER": "unknown_provider"}, clear=True)
+    def test_unknown_llm_provider_falls_through(self):
+        self.assertIsNone(detect_provider())
+
+
+class TestClampTemperature(unittest.TestCase):
+    """Tests for temperature clamping per provider."""
+
+    def test_minimax_clamp_within_range(self):
+        self.assertEqual(clamp_temperature(0.7, "minimax"), 0.7)
+
+    def test_minimax_clamp_upper_bound(self):
+        self.assertEqual(clamp_temperature(1.5, "minimax"), 1.0)
+
+    def test_minimax_clamp_lower_bound(self):
+        self.assertEqual(clamp_temperature(-0.1, "minimax"), 0.0)
+
+    def test_minimax_zero_temperature(self):
+        self.assertEqual(clamp_temperature(0.0, "minimax"), 0.0)
+
+    def test_openai_allows_higher_temp(self):
+        self.assertEqual(clamp_temperature(1.5, "openai"), 1.5)
+
+    def test_no_provider_passthrough(self):
+        self.assertEqual(clamp_temperature(1.5, None), 1.5)
+
+    def test_unknown_provider_passthrough(self):
+        self.assertEqual(clamp_temperature(2.5, "unknown"), 2.5)
+
+
+class TestGetProviderConfig(unittest.TestCase):
+    """Tests for get_provider_config() configuration resolution."""
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_no_provider_defaults(self):
+        cfg = get_provider_config(None)
+        self.assertEqual(cfg["model_name"], "deepseek-chat")
+        self.assertIsNone(cfg["base_url"])
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "mk"}, clear=True)
+    def test_minimax_provider_config(self):
+        cfg = get_provider_config("minimax")
+        self.assertEqual(cfg["base_url"], "https://api.minimax.io/v1")
+        self.assertEqual(cfg["api_key"], "mk")
+        self.assertEqual(cfg["model_name"], "MiniMax-M2.7")
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "mk", "MODEL_NAME": "MiniMax-M2.5"}, clear=True)
+    def test_model_name_env_overrides_preset(self):
+        cfg = get_provider_config("minimax")
+        self.assertEqual(cfg["model_name"], "MiniMax-M2.5")
+
+    @patch.dict(os.environ, {"MINIMAX_API_KEY": "mk", "OPENAI_BASE_URL": "https://custom.example.com/v1"}, clear=True)
+    def test_base_url_env_overrides_preset(self):
+        cfg = get_provider_config("minimax")
+        self.assertEqual(cfg["base_url"], "https://custom.example.com/v1")
+
+    @patch.dict(os.environ, {"OPENAI_API_KEY": "ok", "OPENAI_BASE_URL": "https://api.deepseek.com/v1"}, clear=True)
+    def test_generic_openai_env_vars(self):
+        cfg = get_provider_config(None)
+        self.assertEqual(cfg["api_key"], "ok")
+        self.assertEqual(cfg["base_url"], "https://api.deepseek.com/v1")
+
+    @patch.dict(os.environ, {"DEEPSEEK_API_KEY": "dk"}, clear=True)
+    def test_deepseek_provider_config(self):
+        cfg = get_provider_config("deepseek")
+        self.assertEqual(cfg["base_url"], "https://api.deepseek.com/v1")
+        self.assertEqual(cfg["api_key"], "dk")
+        self.assertEqual(cfg["model_name"], "deepseek-chat")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add multi-provider support with auto-detection for **MiniMax**, DeepSeek, and OpenAI
- MiniMax models (M2.7, M2.5, M2.5-highspeed) supported via OpenAI-compatible API
- Automatic temperature clamping per provider, LLM_PROVIDER env var for explicit selection
- README updated with MiniMax setup instructions (auto-detect + manual GitHub Actions config)

## Changes

| File | Description |
|------|-------------|
| ai/providers.py | Provider presets, auto-detection via API key env vars, config resolution |
| ai/enhance.py | Use provider system for LLM initialization (base_url, api_key, temperature) |
| README.md | Supported providers table, MiniMax setup guide (Option A/B) |
| tests/test_providers.py | 24 unit tests (presets, detect, clamp, config) |
| tests/test_integration.py | 3 config-flow + 2 live API integration tests |

## How it works

Users can switch to MiniMax by simply setting MINIMAX_API_KEY:

```bash
export MINIMAX_API_KEY="your-key"
python enhance.py --data papers.jsonl
```

The provider is auto-detected and the correct base URL, model, and temperature range are applied. Existing DeepSeek/OpenAI workflows remain fully backward-compatible.

## Test plan

- [x] 24 unit tests pass (provider presets, auto-detection, temperature clamping, config resolution)
- [x] 3 integration tests pass (auto-detect flow, explicit provider, manual config)
- [ ] Live API tests require MINIMAX_API_KEY (skipped in CI by default)
