### PR TITLE
fix: handle provider config and filter outages

### DIFF
--- a/ai/content_filter.py
+++ b/ai/content_filter.py
@@ -1,0 +1,27 @@
+"""Best-effort content filtering for generated paper summaries."""
+
+import sys
+
+import requests
+
+
+FILTER_URL = "https://spam.dw-dengwei.workers.dev"
+
+
+def is_sensitive(content: str) -> bool:
+    """Return True only when the filtering service positively flags content.
+
+    Filtering is intentionally fail-open: a rate limit or outage must not make
+    an otherwise successful daily crawl publish an empty data set.
+    """
+    try:
+        response = requests.post(FILTER_URL, json={"text": content}, timeout=5)
+        if response.status_code == 200:
+            return bool(response.json().get("sensitive", False))
+        print(
+            f"Sensitive check unavailable (HTTP {response.status_code}); allowing content",
+            file=sys.stderr,
+        )
+    except requests.RequestException as error:
+        print(f"Sensitive check error; allowing content: {error}", file=sys.stderr)
+    return False

--- a/ai/enhance.py
+++ b/ai/enhance.py
@@ -6,9 +6,6 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import List, Dict
 from queue import Queue
 from threading import Lock
-# INSERT_YOUR_CODE
-import requests
-
 import dotenv
 import argparse
 from tqdm import tqdm
@@ -21,6 +18,8 @@ from langchain.prompts import (
     HumanMessagePromptTemplate,
 )
 from structure import Structure
+from content_filter import is_sensitive
+from runtime import build_chat_openai_kwargs, raise_if_processing_failed
 
 if os.path.exists('.env'):
     dotenv.load_dotenv()
@@ -35,29 +34,6 @@ def parse_args():
     return parser.parse_args()
 
 def process_single_item(chain, item: Dict, language: str) -> Dict:
-    def is_sensitive(content: str) -> bool:
-        """
-        调用 spam.dw-dengwei.workers.dev 接口检测内容是否包含敏感词。
-        返回 True 表示触发敏感词，False 表示未触发。
-        """
-        try:
-            resp = requests.post(
-                "https://spam.dw-dengwei.workers.dev",
-                json={"text": content},
-                timeout=5
-            )
-            if resp.status_code == 200:
-                result = resp.json()
-                # 约定接口返回 {"sensitive": true/false, ...}
-                return result.get("sensitive", True)
-            else:
-                # 如果接口异常，默认不触发敏感词
-                print(f"Sensitive check failed with status {resp.status_code}", file=sys.stderr)
-                return True
-        except Exception as e:
-            print(f"Sensitive check error: {e}", file=sys.stderr)
-            return True
-
     def check_github_code(content: str) -> Dict:
         """提取并验证 GitHub 链接"""
         code_info = {}
@@ -150,9 +126,8 @@ def process_single_item(chain, item: Dict, language: str) -> Dict:
         item['AI'] = {**default_ai_fields, **partial_data}
         print(f"Using partial AI data for {item.get('id', 'unknown')}: {list(partial_data.keys())}", file=sys.stderr)
     except Exception as e:
-        # Catch any other exceptions and provide default values
         print(f"Unexpected error for {item.get('id', 'unknown')}: {e}", file=sys.stderr)
-        item['AI'] = default_ai_fields
+        raise RuntimeError(f"AI request failed for {item.get('id', 'unknown')}") from e
     
     # Final validation to ensure all required fields exist
     for field in default_ai_fields.keys():
@@ -168,9 +143,12 @@ def process_single_item(chain, item: Dict, language: str) -> Dict:
 def process_all_items(data: List[Dict], model_name: str, language: str, max_workers: int) -> List[Dict]:
     """并行处理所有数据项"""
     llm = ChatOpenAI(
-            model=model_name,
-            model_kwargs={"extra_body": {"thinking": {"type": "disabled"}}}
-        ).with_structured_output(Structure, method="function_calling")
+        **build_chat_openai_kwargs(
+            model_name=model_name,
+            base_url=os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1"),
+            api_key=os.environ.get("OPENAI_API_KEY", ""),
+        )
+    ).with_structured_output(Structure, method="function_calling")
 
     print('Connect to:', model_name, file=sys.stderr)
     
@@ -183,6 +161,7 @@ def process_all_items(data: List[Dict], model_name: str, language: str, max_work
     
     # 使用线程池并行处理
     processed_data = [None] * len(data)  # 预分配结果列表
+    processing_errors = []
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         # 提交所有任务
         future_to_idx = {
@@ -202,21 +181,15 @@ def process_all_items(data: List[Dict], model_name: str, language: str, max_work
                 processed_data[idx] = result
             except Exception as e:
                 print(f"Item at index {idx} generated an exception: {e}", file=sys.stderr)
-                # Add default AI fields to ensure consistency
-                processed_data[idx] = data[idx]
-                processed_data[idx]['AI'] = {
-                    "tldr": "Processing failed",
-                    "motivation": "Processing failed",
-                    "method": "Processing failed",
-                    "result": "Processing failed",
-                    "conclusion": "Processing failed"
-                }
+                processing_errors.append(str(e))
+
+    raise_if_processing_failed(processing_errors)
     
     return processed_data
 
 def main():
     args = parse_args()
-    model_name = os.environ.get("MODEL_NAME", 'deepseek-chat')
+    model_name = os.environ.get("MODEL_NAME", "gpt-4o-mini")
     language = os.environ.get("LANGUAGE", 'Chinese')
 
     # 检查并删除目标文件

--- a/ai/runtime.py
+++ b/ai/runtime.py
@@ -1,0 +1,38 @@
+"""Runtime configuration shared by the paper-enhancement job."""
+
+from urllib.parse import urlparse
+
+
+def build_chat_openai_kwargs(model_name: str, base_url: str, api_key: str) -> dict:
+    """Build provider-safe ChatOpenAI settings from workflow configuration."""
+    model_name = model_name.strip()
+    base_url = base_url.strip().rstrip("/")
+    api_key = api_key.strip()
+
+    missing = [
+        name
+        for name, value in (
+            ("MODEL_NAME", model_name),
+            ("OPENAI_BASE_URL", base_url),
+            ("OPENAI_API_KEY", api_key),
+        )
+        if not value
+    ]
+    if missing:
+        raise ValueError(f"Missing required configuration: {', '.join(missing)}")
+
+    kwargs = {
+        "model": model_name,
+        "base_url": base_url,
+        "api_key": api_key,
+    }
+    hostname = urlparse(base_url).hostname or ""
+    if hostname.endswith("volces.com"):
+        kwargs["extra_body"] = {"thinking": {"type": "disabled"}}
+    return kwargs
+
+
+def raise_if_processing_failed(errors: list[str]) -> None:
+    """Make a failed AI batch fail the workflow instead of publishing placeholders."""
+    if errors:
+        raise RuntimeError(f"{len(errors)} paper(s) failed AI enhancement: {errors[0]}")

--- a/ai/tests/test_content_filter.py
+++ b/ai/tests/test_content_filter.py
@@ -1,0 +1,31 @@
+import unittest
+from unittest.mock import patch
+
+from content_filter import is_sensitive
+
+
+class FakeResponse:
+    def __init__(self, status_code, payload=None):
+        self.status_code = status_code
+        self.payload = payload or {}
+
+    def json(self):
+        return self.payload
+
+
+class SensitiveFilterTests(unittest.TestCase):
+    @patch("content_filter.requests.post", return_value=FakeResponse(429))
+    def test_service_rate_limit_does_not_block_a_paper(self, _post):
+        """Catches the fail-closed branch that silently removed every paper on a 429."""
+        self.assertFalse(is_sensitive("A paper abstract"))
+
+    @patch(
+        "content_filter.requests.post",
+        return_value=FakeResponse(200, {"sensitive": True}),
+    )
+    def test_confirmed_sensitive_content_is_blocked(self, _post):
+        self.assertTrue(is_sensitive("A paper abstract"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ai/tests/test_runtime.py
+++ b/ai/tests/test_runtime.py
@@ -1,0 +1,40 @@
+import unittest
+
+from runtime import build_chat_openai_kwargs, raise_if_processing_failed
+
+
+class BuildChatOpenAIKwargsTests(unittest.TestCase):
+    def test_openai_configuration_strips_key_and_omits_provider_extensions(self):
+        """Catches accidentally sending a provider-specific `thinking` field to OpenAI."""
+        kwargs = build_chat_openai_kwargs(
+            model_name="gpt-4.1-mini",
+            base_url="https://api.openai.com/v1/",
+            api_key="  sk-test-key  ",
+        )
+
+        self.assertEqual("gpt-4.1-mini", kwargs["model"])
+        self.assertEqual("https://api.openai.com/v1", kwargs["base_url"])
+        self.assertEqual("sk-test-key", kwargs["api_key"])
+        self.assertNotIn("extra_body", kwargs)
+
+    def test_volcengine_configuration_disables_thinking_with_extra_body(self):
+        """Catches losing the Ark-specific request option required by the current model."""
+        kwargs = build_chat_openai_kwargs(
+            model_name="doubao-seed-1.6-250615",
+            base_url="https://ark.cn-beijing.volces.com/api/v3",
+            api_key="ark-test-key",
+        )
+
+        self.assertEqual(
+            {"thinking": {"type": "disabled"}},
+            kwargs["extra_body"],
+        )
+
+    def test_processing_error_is_reported_after_a_batch(self):
+        """Catches swallowing authentication failures and publishing fallback summaries."""
+        with self.assertRaisesRegex(RuntimeError, r"2 paper\(s\) failed"):
+            raise_if_processing_failed(["401 Unauthorized", "401 Unauthorized"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "dotenv>=0.9.9",
     "langchain>=0.3.20",
     "langchain-openai>=0.3.9",
+    "requests>=2.32.3",
     "scrapy>=2.12.0",
     "tqdm>=4.67.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.12.4'",
@@ -208,6 +208,7 @@ dependencies = [
     { name = "dotenv" },
     { name = "langchain" },
     { name = "langchain-openai" },
+    { name = "requests" },
     { name = "scrapy" },
     { name = "tqdm" },
 ]
@@ -218,6 +219,7 @@ requires-dist = [
     { name = "dotenv", specifier = ">=0.9.9" },
     { name = "langchain", specifier = ">=0.3.20" },
     { name = "langchain-openai", specifier = ">=0.3.9" },
+    { name = "requests", specifier = ">=2.32.3" },
     { name = "scrapy", specifier = ">=2.12.0" },
     { name = "tqdm", specifier = ">=4.67.1" },
 ]
@@ -281,7 +283,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/ec/bad1ac26764d26aa1353216fcbfa4670050f66d445448aafa227f8b16e80/greenlet-3.1.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:4afe7ea89de619adc868e087b4d2359282058479d7cfb94970adf4b55284574d", size = 274260, upload-time = "2024-09-20T17:08:07.301Z" },
     { url = "https://files.pythonhosted.org/packages/66/d4/c8c04958870f482459ab5956c2942c4ec35cac7fe245527f1039837c17a9/greenlet-3.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f406b22b7c9a9b4f8aa9d2ab13d6ae0ac3e85c9a809bd590ad53fed2bf70dc79", size = 649064, upload-time = "2024-09-20T17:36:47.628Z" },
     { url = "https://files.pythonhosted.org/packages/51/41/467b12a8c7c1303d20abcca145db2be4e6cd50a951fa30af48b6ec607581/greenlet-3.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c3a701fe5a9695b238503ce5bbe8218e03c3bcccf7e204e455e7462d770268aa", size = 663420, upload-time = "2024-09-20T17:39:21.258Z" },
-    { url = "https://files.pythonhosted.org/packages/27/8f/2a93cd9b1e7107d5c7b3b7816eeadcac2ebcaf6d6513df9abaf0334777f6/greenlet-3.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2846930c65b47d70b9d178e89c7e1a69c95c1f68ea5aa0a58646b7a96df12441", size = 658035, upload-time = "2024-09-20T17:44:26.501Z" },
     { url = "https://files.pythonhosted.org/packages/57/5c/7c6f50cb12be092e1dccb2599be5a942c3416dbcfb76efcf54b3f8be4d8d/greenlet-3.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:99cfaa2110534e2cf3ba31a7abcac9d328d1d9f1b95beede58294a60348fba36", size = 660105, upload-time = "2024-09-20T17:08:42.048Z" },
     { url = "https://files.pythonhosted.org/packages/f1/66/033e58a50fd9ec9df00a8671c74f1f3a320564c6415a4ed82a1c651654ba/greenlet-3.1.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1443279c19fca463fc33e65ef2a935a5b09bb90f978beab37729e1c3c6c25fe9", size = 613077, upload-time = "2024-09-20T17:08:33.707Z" },
     { url = "https://files.pythonhosted.org/packages/19/c5/36384a06f748044d06bdd8776e231fadf92fc896bd12cb1c9f5a1bda9578/greenlet-3.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b7cede291382a78f7bb5f04a529cb18e068dd29e0fb27376074b6d0317bf4dd0", size = 1135975, upload-time = "2024-09-20T17:44:15.989Z" },
@@ -290,7 +291,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/57/0db4940cd7bb461365ca8d6fd53e68254c9dbbcc2b452e69d0d41f10a85e/greenlet-3.1.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:05175c27cb459dcfc05d026c4232f9de8913ed006d42713cb8a5137bd49375f1", size = 272990, upload-time = "2024-09-20T17:08:26.312Z" },
     { url = "https://files.pythonhosted.org/packages/1c/ec/423d113c9f74e5e402e175b157203e9102feeb7088cee844d735b28ef963/greenlet-3.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:935e943ec47c4afab8965954bf49bfa639c05d4ccf9ef6e924188f762145c0ff", size = 649175, upload-time = "2024-09-20T17:36:48.983Z" },
     { url = "https://files.pythonhosted.org/packages/a9/46/ddbd2db9ff209186b7b7c621d1432e2f21714adc988703dbdd0e65155c77/greenlet-3.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:667a9706c970cb552ede35aee17339a18e8f2a87a51fba2ed39ceeeb1004798a", size = 663425, upload-time = "2024-09-20T17:39:22.705Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/f9/9c82d6b2b04aa37e38e74f0c429aece5eeb02bab6e3b98e7db89b23d94c6/greenlet-3.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b8a678974d1f3aa55f6cc34dc480169d58f2e6d8958895d68845fa4ab566509e", size = 657736, upload-time = "2024-09-20T17:44:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/d9/42/b87bc2a81e3a62c3de2b0d550bf91a86939442b7ff85abb94eec3fc0e6aa/greenlet-3.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:efc0f674aa41b92da8c49e0346318c6075d734994c3c4e4430b1c3f853e498e4", size = 660347, upload-time = "2024-09-20T17:08:45.56Z" },
     { url = "https://files.pythonhosted.org/packages/37/fa/71599c3fd06336cdc3eac52e6871cfebab4d9d70674a9a9e7a482c318e99/greenlet-3.1.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0153404a4bb921f0ff1abeb5ce8a5131da56b953eda6e14b88dc6bbc04d2049e", size = 615583, upload-time = "2024-09-20T17:08:36.85Z" },
     { url = "https://files.pythonhosted.org/packages/4e/96/e9ef85de031703ee7a4483489b40cf307f93c1824a02e903106f2ea315fe/greenlet-3.1.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:275f72decf9932639c1c6dd1013a1bc266438eb32710016a1c742df5da6e60a1", size = 1133039, upload-time = "2024-09-20T17:44:18.287Z" },
@@ -298,7 +298,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/1b/54336d876186920e185066d8c3024ad55f21d7cc3683c856127ddb7b13ce/greenlet-3.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:b42703b1cf69f2aa1df7d1030b9d77d3e584a70755674d60e710f0af570f3761", size = 299490, upload-time = "2024-09-20T17:17:09.501Z" },
     { url = "https://files.pythonhosted.org/packages/5f/17/bea55bf36990e1638a2af5ba10c1640273ef20f627962cf97107f1e5d637/greenlet-3.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f1695e76146579f8c06c1509c7ce4dfe0706f49c6831a817ac04eebb2fd02011", size = 643731, upload-time = "2024-09-20T17:36:50.376Z" },
     { url = "https://files.pythonhosted.org/packages/78/d2/aa3d2157f9ab742a08e0fd8f77d4699f37c22adfbfeb0c610a186b5f75e0/greenlet-3.1.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7876452af029456b3f3549b696bb36a06db7c90747740c5302f74a9e9fa14b13", size = 649304, upload-time = "2024-09-20T17:39:24.55Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/8e/d0aeffe69e53ccff5a28fa86f07ad1d2d2d6537a9506229431a2a02e2f15/greenlet-3.1.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4ead44c85f8ab905852d3de8d86f6f8baf77109f9da589cb4fa142bd3b57b475", size = 646537, upload-time = "2024-09-20T17:44:31.102Z" },
     { url = "https://files.pythonhosted.org/packages/05/79/e15408220bbb989469c8871062c97c6c9136770657ba779711b90870d867/greenlet-3.1.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8320f64b777d00dd7ccdade271eaf0cad6636343293a25074cc5566160e4de7b", size = 642506, upload-time = "2024-09-20T17:08:47.852Z" },
     { url = "https://files.pythonhosted.org/packages/18/87/470e01a940307796f1d25f8167b551a968540fbe0551c0ebb853cb527dd6/greenlet-3.1.1-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6510bf84a6b643dabba74d3049ead221257603a253d0a9873f55f6a59a65f822", size = 602753, upload-time = "2024-09-20T17:08:38.079Z" },
     { url = "https://files.pythonhosted.org/packages/e2/72/576815ba674eddc3c25028238f74d7b8068902b3968cbe456771b166455e/greenlet-3.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:04b013dc07c96f83134b1e99888e7a79979f1a247e2a9f59697fa14b5862ed01", size = 1122731, upload-time = "2024-09-20T17:44:20.556Z" },


### PR DESCRIPTION
## Summary
- send the `thinking` extension only to Volcengine-compatible endpoints
- fail the workflow on AI authentication or request failures instead of publishing placeholders
- allow papers through when the external sensitive-content service is rate-limited or unavailable
- add regression tests for provider configuration and filtering behavior

## Verification
- `cd ai && ../.venv/bin/python -m unittest discover -s tests -v`
- GitHub Actions run completed successfully with the OpenAI configuration